### PR TITLE
Some fixes and status endpoint can conditionally return JSON

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 sphinx
+pytz

--- a/server/protected.py
+++ b/server/protected.py
@@ -38,4 +38,12 @@ def run_load_tests():
 
 @bp_restrict.route('/status', methods=['GET'])
 def load_test_status():
-    return cmd.get_status()
+    stat, code, last_run = cmd.get_status()
+    if flask.request.accept_mimetypes.accept_json:
+        jstat = {
+            'lastRun': last_run,
+            'code': code,
+            'message': stat,
+        }
+        return jstat, code
+    return stat, code

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,8 @@ setuptools.setup(
     description='',
     long_description='',
     packages=['server'],
-    install_requires=['flask'],
+    install_requires=[
+        'flask',
+        'pytz',
+    ],
 )


### PR DESCRIPTION
- Corrected bug where if  no tests were run, it'd return "In Progress". Now it returns "Not Started".
- Moved logic for status to the cmd module to avoid the need to access the protected _STAT object
- If the status endpoint receives 'Accept: application/json' then it'll return in JSON along with last run time and status code in body.